### PR TITLE
Fix unit test on Python 3.3+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# PHP related files
 /vendor
 /composer.lock
 /composer.phar
+
+# Python Cache
+__pycache__/

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 test_php:
 	@echo -e "\n\033[92m\033[1mPHP\033[0m\033[0m"
-	./vendor/bin/phpunit --colors --verbose --bootstrap ./tests/php/phpunit.php ./tests/php/
+	./vendor/bin/phpunit --colors=always --verbose --bootstrap ./tests/php/phpunit.php ./tests/php/
 
 test_python:
 	@echo -e "\n\033[92m\033[1mPYTHON\033[0m\033[0m"

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+test: test_php test_python
+
 test_php:
 	@echo -e "\n\033[92m\033[1mPHP\033[0m\033[0m"
 	./vendor/bin/phpunit --colors=always --verbose --bootstrap ./tests/php/phpunit.php ./tests/php/
@@ -6,6 +8,4 @@ test_python:
 	@echo -e "\n\033[92m\033[1mPYTHON\033[0m\033[0m"
 	python3 -m unittest discover tests/python/ -p '*_test.py' -v
 
-test:
-	make test_php
-	make test_python
+.PHONY: test test_php test_python

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 test: test_php test_python
 
 test_php:
-	@echo -e "\n\033[92m\033[1mPHP\033[0m\033[0m"
+	@printf "\n\033[92m\033[1mPHP\033[0m\033[0m\n"
 	./vendor/bin/phpunit --colors=always --verbose --bootstrap ./tests/php/phpunit.php ./tests/php/
 
 test_python:
-	@echo -e "\n\033[92m\033[1mPYTHON\033[0m\033[0m"
+	@printf "\n\033[92m\033[1mPYTHON\033[0m\033[0m\n"
 	python3 -m unittest discover tests/python/ -p '*_test.py' -v
 
 .PHONY: test test_php test_python

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 test_php:
-	@echo "\n\033[92m\033[1mPHP\033[0m\033[0m"
+	@echo -e "\n\033[92m\033[1mPHP\033[0m\033[0m"
 	./vendor/bin/phpunit --colors --verbose --bootstrap ./tests/php/phpunit.php ./tests/php/
 
 test_python:
-	@echo "\n\033[92m\033[1mPYTHON\033[0m\033[0m"
+	@echo -e "\n\033[92m\033[1mPYTHON\033[0m\033[0m"
 	python3 -m unittest discover tests/python/ -p '*_test.py' -v
 
 test:

--- a/tests/python/restclient_test.py
+++ b/tests/python/restclient_test.py
@@ -1,7 +1,7 @@
 import sys
 import os
 import unittest
-from mock import patch, Mock
+from unittest.mock import patch, Mock
 import time
 sys.path.append(os.path.dirname(__file__) + '/../../python')
 from RestClient import RestClient, APIException


### PR DESCRIPTION
`mock` has been included in the `unittest` module (since Python3.3), and can be imported by `import unittest.mock`. Should use that in unit test so the tests can be run without installation of any external library.

Resolve #11